### PR TITLE
return false in handler prevents binding other click handlers

### DIFF
--- a/js/jquery.smartTab.js
+++ b/js/jquery.smartTab.js
@@ -65,10 +65,10 @@
                 
       function setEvents(){
         $(tabs).bind("click", function(e){
-          if(tabs.index(this)==obj.data('curTabIdx')) return false;
-          showTab(tabs.index(this));
-          if(options.autoProgress) restartAutoProgress();
-          return false;
+          if(tabs.index(this)!=obj.data('curTabIdx')) {
+            showTab(tabs.index(this));
+            if(options.autoProgress) restartAutoProgress(); 
+          }
         });
 
         if(options.keyNavigation){

--- a/js/jquery.smartTab.js
+++ b/js/jquery.smartTab.js
@@ -65,6 +65,7 @@
                 
       function setEvents(){
         $(tabs).bind("click", function(e){
+          e.preventDefault();
           if(tabs.index(this)!=obj.data('curTabIdx')) {
             showTab(tabs.index(this));
             if(options.autoProgress) restartAutoProgress(); 


### PR DESCRIPTION
ran into this issue at work where we were trying to add additional events when tabs are clicked. the return false prevents those events from firing though.
