### PR TITLE
check if st > tabs.length, which causes problem

### DIFF
--- a/js/jquery.smartTab.js
+++ b/js/jquery.smartTab.js
@@ -47,7 +47,8 @@
           var stt = getTabState();
           if(stt) st = stt;
         }
-        st = (st) ? st : 0;
+        if(!st || st > tabs.length)
+          st = 0;
         showTab(st);                                    
       }
                 


### PR DESCRIPTION
In case of multiple pages using SmartTab, it is possible to have a great st value from one page, and when I switch to the other page whose number of tab is smaller, the page won't display and cannot be selected.

One quick fix is once the situation occurs, assign st value to zero.
