### PR TITLE
Fix destroy function

### DIFF
--- a/src/js/jquery.smartTab.js
+++ b/src/js/jquery.smartTab.js
@@ -595,7 +595,12 @@
             let instance = $.data(this[0], 'smartTab');
 
             if (options === 'destroy') {
-                $.data(this, 'smartTab', null);
+                if (instance != null) {
+                    instance.tabs.off("click");
+                    instance.main.data('click-init', false)
+                    $.data(this[0], 'smartTab', null);
+                }
+                return this;
             }
 
             if (instance instanceof SmartTab && typeof instance[options] === 'function') {


### PR DESCRIPTION
The destroy function was not working at all. It was attempting to remove the data from the jquery collection rather than the instance.  

This change removes the data from the instance and also removes the click event handler.