### PR TITLE
fix previous tab index in showTab event

### DIFF
--- a/src/js/jquery.smartTab.js
+++ b/src/js/jquery.smartTab.js
@@ -286,7 +286,7 @@
               // Fix height with content
               this._fixHeight(idx);
               // Trigger "showTab" event
-              this._triggerEvent("showTab", [selTab, this.current_index]);
+              this._triggerEvent("showTab", [selTab, idx]);
               // Restart auto progress if enabled
               this._restartAutoProgress();
           });


### PR DESCRIPTION
When listening to 'showTab' event you get previous tab index. And on first init you even get null


